### PR TITLE
:sparkles: exclude current blog post from related posts

### DIFF
--- a/src/components/RelatedBlogs.js
+++ b/src/components/RelatedBlogs.js
@@ -4,12 +4,15 @@ import styled from 'styled-components';
 import { Link } from 'gatsby';
 import { featuredBlogs } from '../constants/blog-posts';
 
-function RelatedBlogPosts({ className }) {
+function RelatedBlogPosts({ className, currentPath }) {
+
+  const blogPosts = featuredBlogs.filter(post => post.path != currentPath);
+
   return (
     <div className={className}>
       <h2>Other posts I've written</h2>
       <ul>
-        {featuredBlogs.map(post => (
+        {blogPosts.map(post => (
           <li>
             <Link to={post.path}>{post.title}</Link>
           </li>

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -22,7 +22,7 @@ export default function Template({
         <PostContainer>
           <h1>{post.frontmatter.title}</h1>
           <div className="blog-post-content" dangerouslySetInnerHTML={{ __html: post.html }} />
-          <RelatedBlogPosts />
+          <RelatedBlogPosts currentPath={post.frontmatter.path} />
         </PostContainer>
         <Footer />
       </Layout>


### PR DESCRIPTION
This PR:

- Filters the list of related blog post so the user doesn't see a link to the blog post they're on in the 'other blog posts' category.